### PR TITLE
Add shared order flow foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ We are building a Java 21+ JavaFX application for a cafe with three roles:
 - The manager dashboard supports adding, editing, and removing menu items, including beverage sizes/customizations and ingredient usage
 - Manager menu and inventory changes save back to JSON
 - Pending and fulfilled order queues now have a JSON persistence foundation
+- Customer/barista order foundation includes draft orders, line-item pricing, selected sizes/customizations, inventory validation, and FIFO queue support
 
 ## Build And Run
 
@@ -78,7 +79,7 @@ mvn javafx:run
 1. Invite teammates and the instructor collaborator.
 2. Finish assigning major ownership areas across the team.
 3. Create issues for design, coding, testing, diagrams, and reflection work.
-4. Build customer ordering and barista queue screens against the shared service layer.
+4. Build customer ordering and barista queue screens against the shared order service layer.
 5. Integrate teammate branches carefully so FXML/root-level files are moved into the Maven JavaFX package structure.
 
 ## Project Notes

--- a/docs/project-notes.md
+++ b/docs/project-notes.md
@@ -83,3 +83,15 @@ This file is the shared repo-level notes log for setup changes, progress updates
 - Reviewed teammate branch diffs before integration:
   - `customer-flow` has useful customer service/model work, but some Java/FXML files are currently outside the Maven package structure
   - `ameer/barista-flow` appears behind the current shared scaffold and should be updated before integration
+
+## April 22 2026
+
+- Started `andre/order-flow-foundation` from the updated `main` branch.
+- Added shared order-flow support for customer and barista screens:
+  - `OrderItem` now stores selected beverage size and customizations
+  - `OrderPricingService` centralizes unit, line, and order total calculations
+  - `CustomerOrderService` manages a customer's draft order before submitting it
+  - `InventoryService` can validate and consume inventory for a whole order
+  - `OrderService` exposes pending lookup and next-order FIFO helper methods
+  - order JSON persistence now keeps selected size/customization information
+- Confirmed the project compiles with `.\mvnw.cmd clean compile`.

--- a/src/main/java/edu/metrostate/brewcafe/model/OrderItem.java
+++ b/src/main/java/edu/metrostate/brewcafe/model/OrderItem.java
@@ -1,12 +1,24 @@
 package edu.metrostate.brewcafe.model;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
 public class OrderItem {
     private final MenuItem menuItem;
     private int quantity;
+    private SizeOption selectedSize;
+    private final List<Customization> selectedCustomizations = new ArrayList<>();
 
     public OrderItem(MenuItem menuItem, int quantity) {
+        this(menuItem, quantity, null, List.of());
+    }
+
+    public OrderItem(MenuItem menuItem, int quantity, SizeOption selectedSize, List<Customization> selectedCustomizations) {
         this.menuItem = menuItem;
         this.quantity = quantity;
+        this.selectedSize = selectedSize;
+        setSelectedCustomizations(selectedCustomizations);
     }
 
     public MenuItem getMenuItem() {
@@ -19,5 +31,24 @@ public class OrderItem {
 
     public void setQuantity(int quantity) {
         this.quantity = quantity;
+    }
+
+    public SizeOption getSelectedSize() {
+        return selectedSize;
+    }
+
+    public void setSelectedSize(SizeOption selectedSize) {
+        this.selectedSize = selectedSize;
+    }
+
+    public List<Customization> getSelectedCustomizations() {
+        return Collections.unmodifiableList(selectedCustomizations);
+    }
+
+    public void setSelectedCustomizations(List<Customization> customizations) {
+        selectedCustomizations.clear();
+        if (customizations != null) {
+            selectedCustomizations.addAll(customizations);
+        }
     }
 }

--- a/src/main/java/edu/metrostate/brewcafe/persistence/JsonDataLoader.java
+++ b/src/main/java/edu/metrostate/brewcafe/persistence/JsonDataLoader.java
@@ -183,7 +183,12 @@ public class JsonDataLoader {
             for (OrderItemDataRaw rawItem : rawOrder.items()) {
                 MenuItem menuItem = menuById.get(rawItem.menuItemId());
                 if (menuItem != null) {
-                    order.addItem(new OrderItem(menuItem, rawItem.quantity()));
+                    order.addItem(new OrderItem(
+                            menuItem,
+                            rawItem.quantity(),
+                            findSelectedSize(menuItem, rawItem.selectedSizeName()),
+                            findSelectedCustomizations(menuItem, rawItem.selectedCustomizationNames())
+                    ));
                 }
             }
             orders.add(order);
@@ -196,11 +201,39 @@ public class JsonDataLoader {
         List<OrderDataRaw> orderData = new ArrayList<>();
         for (Order order : orders) {
             List<OrderItemDataRaw> items = order.getItems().stream()
-                    .map(item -> new OrderItemDataRaw(item.getMenuItem().getId(), item.getQuantity()))
+                    .map(item -> new OrderItemDataRaw(
+                            item.getMenuItem().getId(),
+                            item.getQuantity(),
+                            item.getSelectedSize() == null ? null : item.getSelectedSize().name(),
+                            item.getSelectedCustomizations().stream()
+                                    .map(Customization::name)
+                                    .toList()
+                    ))
                     .toList();
             orderData.add(new OrderDataRaw(order.getId(), order.getCustomerName(), order.getStatus(), items));
         }
         return orderData;
+    }
+
+    private SizeOption findSelectedSize(MenuItem menuItem, String selectedSizeName) {
+        if (!(menuItem instanceof Beverage beverage) || selectedSizeName == null || selectedSizeName.isBlank()) {
+            return null;
+        }
+
+        return beverage.getSizes().stream()
+                .filter(size -> size.name().equals(selectedSizeName))
+                .findFirst()
+                .orElse(null);
+    }
+
+    private List<Customization> findSelectedCustomizations(MenuItem menuItem, List<String> customizationNames) {
+        if (!(menuItem instanceof Beverage beverage) || customizationNames == null || customizationNames.isEmpty()) {
+            return List.of();
+        }
+
+        return beverage.getCustomizations().stream()
+                .filter(customization -> customizationNames.contains(customization.name()))
+                .toList();
     }
 
     private record UsersData(List<User> users) {
@@ -240,6 +273,11 @@ public class JsonDataLoader {
     private record OrderDataRaw(String id, String customerName, OrderStatus status, List<OrderItemDataRaw> items) {
     }
 
-    private record OrderItemDataRaw(String menuItemId, int quantity) {
+    private record OrderItemDataRaw(
+            String menuItemId,
+            int quantity,
+            String selectedSizeName,
+            List<String> selectedCustomizationNames
+    ) {
     }
 }

--- a/src/main/java/edu/metrostate/brewcafe/service/CustomerOrderService.java
+++ b/src/main/java/edu/metrostate/brewcafe/service/CustomerOrderService.java
@@ -1,0 +1,106 @@
+package edu.metrostate.brewcafe.service;
+
+import edu.metrostate.brewcafe.model.Customization;
+import edu.metrostate.brewcafe.model.MenuItem;
+import edu.metrostate.brewcafe.model.Order;
+import edu.metrostate.brewcafe.model.OrderItem;
+import edu.metrostate.brewcafe.model.OrderStatus;
+import edu.metrostate.brewcafe.model.SizeOption;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+
+// Owns the customer's draft order before it is submitted to the shared barista queue.
+public class CustomerOrderService {
+    private final CafeApplicationState applicationState;
+    private Order currentOrder;
+    private int nextOrderNumber;
+
+    public CustomerOrderService(CafeApplicationState applicationState) {
+        this.applicationState = applicationState;
+        nextOrderNumber = applicationState.getOrderService().getPendingOrders().size()
+                + applicationState.getOrderService().getFulfilledOrders().size()
+                + 1;
+    }
+
+    public void startNewOrder(String customerName) {
+        if (customerName == null || customerName.isBlank()) {
+            throw new IllegalArgumentException("Customer name is required.");
+        }
+
+        currentOrder = new Order(generateOrderId(), customerName.trim(), OrderStatus.PENDING);
+    }
+
+    public Optional<Order> getCurrentOrder() {
+        return Optional.ofNullable(currentOrder);
+    }
+
+    public OrderItem addItemToCurrentOrder(
+            MenuItem menuItem,
+            int quantity,
+            SizeOption selectedSize,
+            List<Customization> selectedCustomizations
+    ) {
+        ensureActiveOrder();
+        validateOrderItem(menuItem, quantity);
+
+        OrderItem orderItem = new OrderItem(menuItem, quantity, selectedSize, selectedCustomizations);
+        currentOrder.addItem(orderItem);
+        return orderItem;
+    }
+
+    public void removeItemFromCurrentOrder(OrderItem orderItem) {
+        ensureActiveOrder();
+        currentOrder.removeItem(orderItem);
+    }
+
+    public void clearCurrentOrder() {
+        ensureActiveOrder();
+        currentOrder.clearItems();
+    }
+
+    public boolean canPlaceCurrentOrder() {
+        return currentOrder != null
+                && !currentOrder.getItems().isEmpty()
+                && applicationState.getInventoryService().canFulfillOrder(currentOrder);
+    }
+
+    public Order placeCurrentOrder() throws IOException {
+        ensureActiveOrder();
+        if (currentOrder.getItems().isEmpty()) {
+            throw new IllegalStateException("Cannot place an empty order.");
+        }
+
+        if (!applicationState.getInventoryService().consumeForOrder(currentOrder)) {
+            throw new IllegalStateException("Cannot place order because inventory is too low.");
+        }
+
+        Order placedOrder = currentOrder;
+        applicationState.getOrderService().addOrder(placedOrder);
+        applicationState.saveInventoryData();
+        applicationState.saveOrderData();
+        currentOrder = null;
+        return placedOrder;
+    }
+
+    private void ensureActiveOrder() {
+        if (currentOrder == null) {
+            throw new IllegalStateException("Start a customer order first.");
+        }
+    }
+
+    private void validateOrderItem(MenuItem menuItem, int quantity) {
+        if (menuItem == null) {
+            throw new IllegalArgumentException("Menu item is required.");
+        }
+
+        if (quantity <= 0) {
+            throw new IllegalArgumentException("Quantity must be greater than 0.");
+        }
+    }
+
+    private String generateOrderId() {
+        return "ORDER-" + String.format("%03d", nextOrderNumber++);
+    }
+}

--- a/src/main/java/edu/metrostate/brewcafe/service/InventoryService.java
+++ b/src/main/java/edu/metrostate/brewcafe/service/InventoryService.java
@@ -3,10 +3,14 @@ package edu.metrostate.brewcafe.service;
 import edu.metrostate.brewcafe.model.Ingredient;
 import edu.metrostate.brewcafe.model.IngredientUsage;
 import edu.metrostate.brewcafe.model.MenuItem;
+import edu.metrostate.brewcafe.model.Order;
+import edu.metrostate.brewcafe.model.OrderItem;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 // Owns stock visibility, restocking, and availability checks for manager-controlled inventory.
@@ -59,9 +63,18 @@ public class InventoryService extends AbstractCafeSubject {
     }
 
     public boolean isAvailable(MenuItem menuItem) {
+        return isAvailable(menuItem, 1);
+    }
+
+    public boolean isAvailable(MenuItem menuItem, int quantity) {
+        if (quantity <= 0) {
+            return false;
+        }
+
         for (IngredientUsage usage : menuItem.getIngredientUsages()) {
             Optional<Ingredient> ingredient = getIngredientById(usage.ingredientId());
-            if (ingredient.isEmpty() || ingredient.get().getQuantity() < usage.quantityRequired()) {
+            double requiredQuantity = usage.quantityRequired() * quantity;
+            if (ingredient.isEmpty() || ingredient.get().getQuantity() < requiredQuantity) {
                 return false;
             }
         }
@@ -70,16 +83,53 @@ public class InventoryService extends AbstractCafeSubject {
     }
 
     public boolean consumeForMenuItem(MenuItem menuItem) {
-        if (!isAvailable(menuItem)) {
+        return consumeForMenuItem(menuItem, 1);
+    }
+
+    public boolean consumeForMenuItem(MenuItem menuItem, int quantity) {
+        if (!isAvailable(menuItem, quantity)) {
             return false;
         }
 
         for (IngredientUsage usage : menuItem.getIngredientUsages()) {
             Ingredient ingredient = getIngredientById(usage.ingredientId()).orElseThrow();
-            ingredient.setQuantity(ingredient.getQuantity() - usage.quantityRequired());
+            ingredient.setQuantity(ingredient.getQuantity() - (usage.quantityRequired() * quantity));
         }
 
         notifyObservers("inventory-consumed");
         return true;
+    }
+
+    public boolean canFulfillOrder(Order order) {
+        return buildRequiredIngredientTotals(order).entrySet().stream()
+                .allMatch(entry -> getIngredientById(entry.getKey())
+                        .filter(ingredient -> ingredient.getQuantity() >= entry.getValue())
+                        .isPresent());
+    }
+
+    public boolean consumeForOrder(Order order) {
+        Map<String, Double> requiredTotals = buildRequiredIngredientTotals(order);
+        if (!canFulfillOrder(order)) {
+            return false;
+        }
+
+        for (Map.Entry<String, Double> entry : requiredTotals.entrySet()) {
+            Ingredient ingredient = getIngredientById(entry.getKey()).orElseThrow();
+            ingredient.setQuantity(ingredient.getQuantity() - entry.getValue());
+        }
+
+        notifyObservers("inventory-consumed");
+        return true;
+    }
+
+    private Map<String, Double> buildRequiredIngredientTotals(Order order) {
+        Map<String, Double> requiredTotals = new HashMap<>();
+        for (OrderItem item : order.getItems()) {
+            for (IngredientUsage usage : item.getMenuItem().getIngredientUsages()) {
+                double requiredQuantity = usage.quantityRequired() * item.getQuantity();
+                requiredTotals.merge(usage.ingredientId(), requiredQuantity, Double::sum);
+            }
+        }
+        return requiredTotals;
     }
 }

--- a/src/main/java/edu/metrostate/brewcafe/service/OrderPricingService.java
+++ b/src/main/java/edu/metrostate/brewcafe/service/OrderPricingService.java
@@ -1,0 +1,43 @@
+package edu.metrostate.brewcafe.service;
+
+import edu.metrostate.brewcafe.model.Customization;
+import edu.metrostate.brewcafe.model.Order;
+import edu.metrostate.brewcafe.model.OrderItem;
+
+// Centralizes order price calculations so customer and barista views show the same totals.
+public class OrderPricingService {
+    public double calculateUnitPrice(OrderItem orderItem) {
+        if (orderItem == null || orderItem.getMenuItem() == null) {
+            throw new IllegalArgumentException("Order item and menu item are required.");
+        }
+
+        double price = orderItem.getMenuItem().getBasePrice();
+        if (orderItem.getSelectedSize() != null) {
+            price += orderItem.getSelectedSize().priceAdjustment();
+        }
+
+        for (Customization customization : orderItem.getSelectedCustomizations()) {
+            price += customization.extraCost();
+        }
+
+        return price;
+    }
+
+    public double calculateLineTotal(OrderItem orderItem) {
+        if (orderItem == null) {
+            throw new IllegalArgumentException("Order item is required.");
+        }
+
+        return calculateUnitPrice(orderItem) * orderItem.getQuantity();
+    }
+
+    public double calculateOrderTotal(Order order) {
+        if (order == null) {
+            throw new IllegalArgumentException("Order is required.");
+        }
+
+        return order.getItems().stream()
+                .mapToDouble(this::calculateLineTotal)
+                .sum();
+    }
+}

--- a/src/main/java/edu/metrostate/brewcafe/service/OrderService.java
+++ b/src/main/java/edu/metrostate/brewcafe/service/OrderService.java
@@ -6,6 +6,7 @@ import edu.metrostate.brewcafe.model.OrderStatus;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 // Keeps order queue behavior in one place and provides a base for live updates later.
 public class OrderService extends AbstractCafeSubject {
@@ -22,6 +23,7 @@ public class OrderService extends AbstractCafeSubject {
 
     public void addOrder(Order order) {
         // Keeping queue behavior in a service helps prevent order logic from leaking into the UI.
+        order.setStatus(OrderStatus.PENDING);
         pendingOrders.add(order);
         notifyObservers("order-added");
     }
@@ -32,6 +34,20 @@ public class OrderService extends AbstractCafeSubject {
 
     public List<Order> getFulfilledOrders() {
         return Collections.unmodifiableList(fulfilledOrders);
+    }
+
+    public Optional<Order> getNextPendingOrder() {
+        if (pendingOrders.isEmpty()) {
+            return Optional.empty();
+        }
+
+        return Optional.of(pendingOrders.getFirst());
+    }
+
+    public Optional<Order> getPendingOrderById(String orderId) {
+        return pendingOrders.stream()
+                .filter(order -> order.getId().equals(orderId))
+                .findFirst();
     }
 
     public boolean updateOrderStatus(String orderId, OrderStatus status) {


### PR DESCRIPTION
## Summary

- Adds shared order-flow support for customer and barista screens
- Stores selected beverage size and customizations on order items
- Adds centralized order pricing for unit, line, and order totals
- Adds customer draft-order service and whole-order inventory validation/consumption
- Adds pending/fulfilled order JSON persistence and FIFO queue helpers

## Verification

- Ran `./mvnw.cmd clean compile` successfully locally.